### PR TITLE
django-debug-toolbar 1.10+ support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.rst
 include LICENSE
 recursive-include requests_toolbar/templates *
+recursive-include requests_toolbar/static *

--- a/requests_toolbar/__init__.py
+++ b/requests_toolbar/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 0, 5)
+VERSION = (1, 1, 0)
 
 __version__ = VERSION
 __versionstr__ = '.'.join(map(str, VERSION))

--- a/requests_toolbar/static/requests_toolbar/requests_toolbar.js
+++ b/requests_toolbar/static/requests_toolbar/requests_toolbar.js
@@ -1,0 +1,43 @@
+"use strict";
+
+(function () {
+  // Based on http://youmightnotneedjquery.com/
+  function ready(fn) {
+    if (document.attachEvent ? document.readyState === "complete" : document.readyState !== "loading") {
+      fn();
+    } else {
+      document.addEventListener('DOMContentLoaded', fn);
+    }
+  }
+
+  function toggleClass(el, className) {
+    if (el.classList) {
+      el.classList.toggle(className);
+    } else {
+      var classes = el.className.split(' ');
+      var existingIndex = classes.indexOf(className);
+
+      if (existingIndex >= 0)
+        classes.splice(existingIndex, 1);
+      else
+        classes.push(className);
+
+      el.className = classes.join(' ');
+    }
+  }
+
+  function toggleLink(event) {
+    var link = event.target;
+    var targetElement = document.querySelector(link.getAttribute('href'));
+    if (targetElement) {
+      toggleClass(targetElement, 'requests-toolbar-hidden');
+    }
+  }
+
+  ready(function () {
+    var rtOpenLinks = document.querySelectorAll('.requests-toolbar-open');
+    for (var i = 0; i < rtOpenLinks.length; i++) {
+      rtOpenLinks[i].addEventListener('click', toggleLink);
+    }
+  });
+})();

--- a/requests_toolbar/templates/requests_toolbar/panels/requests.html
+++ b/requests_toolbar/templates/requests_toolbar/panels/requests.html
@@ -1,4 +1,4 @@
-{% load requests_toolbar_tags %}
+{% load static requests_toolbar_tags %}
 <style type="text/css">
     .requests-toolbar-hidden {
         display: none;
@@ -63,11 +63,4 @@
         {% endfor %}
     </tbody>
 </table>
-<script>
-    (function ($, publicAPI) {
-        $('.requests-toolbar-open').click(function(e) {
-            var element = $(e.target);
-            $(element.attr('href')).toggle();
-        })
-    })(djdt.jQuery, djdt);
-</script>
+<script src="{% static 'requests_toolbar/requests_toolbar.js' %}"></script>

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 description-file = README.md
 
 [bumpversion]
-current_version = 1.0.5
+current_version = 1.1.0
 commit = True
 tag = True
 


### PR DESCRIPTION
Since django-debug-toolbar removed jQuery dependency in version 1.10 javascript had to be rewritten in Vanilla JS and moved into .js file.